### PR TITLE
Schedule and debounce player attack checks to avoid duplicate/stale events

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,11 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5785,6 +5785,13 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	++m_attackCheckGeneration;
+	if (m_pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(m_pendingAttackCheckEventId);
+		m_pendingAttackCheckEventId = 0;
+	}
+	m_hasPendingAttackCheck = false;
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5807,39 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		requestAttackCheck();
 	}
 	return true;
+}
+
+void Player::requestAttackCheck() {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+		return;
+	}
+
+	const uint32_t generation = m_attackCheckGeneration;
+	m_hasPendingAttackCheck = true;
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			player->m_pendingAttackCheckEventId = 0;
+			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+				return;
+			}
+
+			player->m_hasPendingAttackCheck = false;
+			player->checkCreatureAttack(true);
+		},
+		0, "Player::requestAttackCheck");
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -720,6 +720,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck();
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1809,9 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation
- Avoid performing immediate attack checks from `Creature::checkCreatureAttack` when the creature is a player to reduce redundant work and potential threading issues.
- Debounce multiple rapid `setAttackedCreature` changes so only a single attack-check runs and stale scheduled checks are ignored.
- Ensure attack checks for players are executed via the dispatcher to keep behavior consistent with other delayed tasks.

### Description
- `Creature::checkCreatureAttack` now delegates to `Player::requestAttackCheck()` when the checked creature is a player instead of scheduling the check directly. 
- `Player::setAttackedCreature` increments an `m_attackCheckGeneration`, cancels any pending scheduled attack-check event, clears the pending flag, and calls `requestAttackCheck()` when a new attacked creature is set. 
- Added `Player::requestAttackCheck()` which schedules an attack check via the dispatcher with generation-based validation to drop stale events and prevents double-scheduling using `m_pendingAttackCheckEventId` and `m_hasPendingAttackCheck`. 
- Declared the new method and added backing members `m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, and `m_hasPendingAttackCheck` to `player.hpp`.

### Testing
- Project compiled successfully after the changes with no compile errors. 
- Ran the automated unit/integration test suite and existing tests related to combat/dispatch scheduling passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Correções de Bugs**
  * Melhorada a gestão de verificações de ataque para criaturas controladas pelo jogador, implementando um sistema de fila mais robusto que evita verificações duplicadas ou desatualizadas durante operações assíncronas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->