### PR TITLE
Debounce player attack-checks to avoid duplicate/stale dispatcher events

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	if (const auto &player = getPlayer()) {
+		// Player attack checks are debounced in Player::requestAttackCheck()
+		// to avoid duplicate/stale dispatcher events when targets change rapidly.
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5785,6 +5785,16 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	// Every target transition gets a new generation; older scheduled checks
+	// are considered stale and must not execute.
+	++m_attackCheckGeneration;
+	if (m_pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(m_pendingAttackCheckEventId);
+		m_pendingAttackCheckEventId = 0;
+	}
+	// Reset pending state for the new generation.
+	m_hasPendingAttackCheck = false;
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5810,41 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		requestAttackCheck();
 	}
 	return true;
+}
+
+void Player::requestAttackCheck() {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	// Debounce: one pending attack-check event per player at a time.
+	if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+		return;
+	}
+
+	const uint32_t generation = m_attackCheckGeneration;
+	m_hasPendingAttackCheck = true;
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			player->m_pendingAttackCheckEventId = 0;
+			// Drop stale callbacks from older generations or already-cleared state.
+			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+				return;
+			}
+
+			player->m_hasPendingAttackCheck = false;
+			player->checkCreatureAttack(true);
+		},
+		0, "Player::requestAttackCheck");
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5844,7 +5844,8 @@ void Player::requestAttackCheck() {
 			player->m_hasPendingAttackCheck = false;
 			player->checkCreatureAttack(true);
 		},
-		0, "Player::requestAttackCheck");
+		0, "Player::requestAttackCheck"
+	);
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -720,6 +720,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck();
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1809,9 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate or stale attack-check dispatcher callbacks when a player changes targets rapidly.
- Avoid race conditions and redundant work from multiple scheduled attack-check events for the same player.

### Description
- `Creature::checkCreatureAttack` now delegates player-specific checks to a new `Player::requestAttackCheck()` to enable debouncing for players.
- Added `Player::requestAttackCheck()` which schedules a single deferred attack-check per player, tracks a per-target `m_attackCheckGeneration`, and ignores stale callbacks from previous generations.
- `Player::setAttackedCreature` now increments `m_attackCheckGeneration`, cancels any outstanding scheduled event, resets pending state, and calls `requestAttackCheck()` when a new target is set.
- Introduced new player members: `m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, and `m_hasPendingAttackCheck`, and declared `requestAttackCheck()` in the header.

### Testing
- The project was built successfully after the changes.
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)