### PR TITLE
Debounce player attack-checks to avoid duplicate/stale dispatcher events

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,10 +3754,15 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
+		const uint32_t generation = m_attackCheckGeneration;
 		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
+			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+				if (const auto &player = self.lock()) {
+					if (generation != player->m_attackCheckGeneration) {
+						return;
+					}
+
+					player->checkCreatureAttack(true);
 				} }, __FUNCTION__
 		);
 
@@ -5785,6 +5790,13 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	++m_attackCheckGeneration;
+	if (m_pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(m_pendingAttackCheckEventId);
+		m_pendingAttackCheckEventId = 0;
+	}
+	m_hasPendingAttackCheck = false;
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5812,55 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	// Debounce: one pending attack-check event per player at a time.
+	if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+		return;
+	}
+
+	const uint32_t generation = m_attackCheckGeneration;
+	m_hasPendingAttackCheck = true;
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
+		delay,
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			// Drop stale callbacks from older generations or already-cleared state.
+			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+				return;
+			}
+
+			player->m_pendingAttackCheckEventId = 0;
+			player->m_hasPendingAttackCheck = false;
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	if (m_pendingAttackCheckEventId == 0) {
+		m_hasPendingAttackCheck = false;
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5856,7 +5856,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			player->m_hasPendingAttackCheck = false;
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	if (m_pendingAttackCheckEventId == 0) {
 		m_hasPendingAttackCheck = false;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5867,7 +5867,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	{
 		std::scoped_lock lock(m_attackCheckMutex);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,22 +3754,21 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const uint32_t generation = m_attackCheckGeneration;
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
-				if (const auto &player = self.lock()) {
-					if (generation != player->m_attackCheckGeneration) {
-						return;
-					}
-
-					player->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			const uint32_t generation = m_attackCheckGeneration;
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						if (generation != player->m_attackCheckGeneration) {
+							return;
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5790,12 +5789,17 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
-	++m_attackCheckGeneration;
-	if (m_pendingAttackCheckEventId != 0) {
-		g_dispatcher().stopEvent(m_pendingAttackCheckEventId);
+	uint64_t pendingAttackCheckEventId = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
 		m_pendingAttackCheckEventId = 0;
+		m_hasPendingAttackCheck = false;
 	}
-	m_hasPendingAttackCheck = false;
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
 
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
@@ -5831,15 +5835,19 @@ void Player::requestAttackCheck(uint32_t delay) {
 		return;
 	}
 
-	// Debounce: one pending attack-check event per player at a time.
-	if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
-		return;
+	uint32_t generation = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			return;
+		}
+		generation = m_attackCheckGeneration;
+		m_hasPendingAttackCheck = true;
 	}
 
-	const uint32_t generation = m_attackCheckGeneration;
-	m_hasPendingAttackCheck = true;
 	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
-	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
+	const auto eventId = g_dispatcher().scheduleEvent(
 		delay,
 		[weakPlayer, generation] {
 			const auto &player = weakPlayer.lock();
@@ -5847,20 +5855,26 @@ void Player::requestAttackCheck(uint32_t delay) {
 				return;
 			}
 
-			// Drop stale callbacks from older generations or already-cleared state.
-			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
-				return;
-			}
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+					return;
+				}
 
-			player->m_pendingAttackCheckEventId = 0;
-			player->m_hasPendingAttackCheck = false;
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck"
-	);
+		"Player::requestAttackCheck");
 
-	if (m_pendingAttackCheckEventId == 0) {
-		m_hasPendingAttackCheck = false;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		m_pendingAttackCheckEventId = eventId;
+		if (m_pendingAttackCheckEventId == 0) {
+			m_hasPendingAttackCheck = false;
+		}
 	}
 }
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -1812,6 +1814,7 @@ private:
 	uint64_t m_pendingAttackCheckEventId = 0;
 	uint32_t m_attackCheckGeneration = 0;
 	bool m_hasPendingAttackCheck = false;
+	mutable std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -720,6 +720,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1809,9 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation
- Avoid duplicate or stale attack-check dispatcher callbacks when a player's target changes rapidly. 
- Ensure scheduled callbacks for players are cancelled or ignored if the player's attack state changes to prevent incorrect or redundant `checkCreatureAttack` calls.

### Description
- Delegate `Creature::checkCreatureAttack` for players to `Player::requestAttackCheck` to centralize debounce logic. 
- Add `Player::requestAttackCheck(uint32_t delay)` which schedules a single debounced attack-check event per player and ignores stale callbacks using a generation counter (`m_attackCheckGeneration`) and `m_hasPendingAttackCheck` flag. 
- Increment `m_attackCheckGeneration` and cancel any pending dispatcher event in `Player::setAttackedCreature`, and replace direct `checkCreatureAttack` calls with `requestAttackCheck` (respecting `lastAttack`/`getAttackSpeed()` delay). 
- In `Player::doAttacking` capture the current generation when scheduling the follow-up task and validate the generation before invoking `checkCreatureAttack(true)` to avoid executing stale callbacks. 
- Add new player state members: `m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, and `m_hasPendingAttackCheck` to `player.hpp` and update related scheduling/cancellation calls.

### Testing
- Compiled the project and executed the automated test suite; all tests passed. 
- Verified (automated CI/smoke) that scheduled attack-check callbacks are debounced and that stale callbacks are not executed during rapid target changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)