### PR TITLE
Debounce player attack checks and centralize scheduling in Player::requestAttackCheck

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,17 +3754,21 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			const uint32_t generation = m_attackCheckGeneration;
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						if (generation != player->m_attackCheckGeneration) {
+							return;
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5785,6 +5789,18 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	uint64_t pendingAttackCheckEventId = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
+		m_pendingAttackCheckEventId = 0;
+		m_hasPendingAttackCheck = false;
+	}
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5816,66 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	uint32_t generation = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			return;
+		}
+		generation = m_attackCheckGeneration;
+		m_hasPendingAttackCheck = true;
+	}
+
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	const auto eventId = g_dispatcher().scheduleEvent(
+		delay,
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+					return;
+				}
+
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		m_pendingAttackCheckEventId = eventId;
+		if (m_pendingAttackCheckEventId == 0) {
+			m_hasPendingAttackCheck = false;
+		}
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5867,7 +5867,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	{
 		std::scoped_lock lock(m_attackCheckMutex);

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -720,6 +722,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1811,10 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
+	mutable std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation

- Prevent duplicate or stale attack-check dispatcher callbacks when a player's target changes rapidly by debouncing attack checks per player.
- Move player-specific scheduling logic out of generic creature code to avoid cross-scheduling races and to allow cancelling stale events cleanly.

### Description

- `Creature::checkCreatureAttack` now delegates player attack checks to `Player::requestAttackCheck()` to avoid creating duplicate dispatcher events for players.
- Added `Player::requestAttackCheck(uint32_t delay)` which debounces attack-check requests, schedules a single delayed event via `g_dispatcher().scheduleEvent`, and uses `m_attackCheckGeneration`, `m_pendingAttackCheckEventId`, and `m_hasPendingAttackCheck` guarded by `m_attackCheckMutex` to drop stale callbacks.
- Updated `Player::setAttackedCreature` to increment the attack-check generation and cancel any previously scheduled dispatcher event by calling `g_dispatcher().stopEvent()` for `m_pendingAttackCheckEventId` before requesting a new attack check with an appropriate delay computed from `lastAttack` and `getAttackSpeed()`.
- Modified `Player::doAttacking` to capture a `generation` token when scheduling the post-attack check, validate the generation at callback time, and use `requestAttackCheck` for classic-speed scheduling paths; also set `setNextActionTask` for the non-classic path as before.
- Added `#include <mutex>` and new member variables (`m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, `m_hasPendingAttackCheck`, and `m_attackCheckMutex`) to `player.hpp`.

### Testing

- Project built successfully after the changes with no compile errors.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)