### PR TITLE
Debounce player attack-checks and add generation-based scheduling

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,17 +3754,28 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			uint32_t generation = 0;
+			{
+				std::scoped_lock lock(m_attackCheckMutex);
+				generation = m_attackCheckGeneration;
+			}
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						{
+							std::scoped_lock lock(player->m_attackCheckMutex);
+							if (generation != player->m_attackCheckGeneration) {
+								return;
+							}
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5785,6 +5796,18 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	uint64_t pendingAttackCheckEventId = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
+		m_pendingAttackCheckEventId = 0;
+		m_hasPendingAttackCheck = false;
+	}
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5823,76 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	uint32_t generation = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			return;
+		}
+		generation = m_attackCheckGeneration;
+		m_hasPendingAttackCheck = true;
+	}
+
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	const auto eventId = g_dispatcher().scheduleEvent(
+		delay,
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+					return;
+				}
+
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	uint64_t eventIdToCancel = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration) {
+			m_pendingAttackCheckEventId = eventId;
+		} else if (eventId != 0) {
+			eventIdToCancel = eventId;
+		}
+
+		if (eventId == 0) {
+			m_hasPendingAttackCheck = false;
+		}
+	}
+
+	if (eventIdToCancel != 0) {
+		g_dispatcher().stopEvent(eventIdToCancel);
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5874,7 +5874,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	uint64_t eventIdToCancel = 0;
 	{

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -720,6 +722,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1811,10 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
+	std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate or stale dispatcher events when a player's attack target changes rapidly by debouncing attack-check scheduling for players.
- Avoid race conditions where scheduled callbacks run for obsolete attack state and simplify Creature attack handling by delegating player-specific logic to Player.

### Description
- Modified `Creature::checkCreatureAttack` to delegate player-specific checks to `Player::requestAttackCheck` to centralize debounce logic.
- Implemented `Player::requestAttackCheck(uint32_t delay)` which schedules a single debounced attack-check event per player using `m_pendingAttackCheckEventId`, `m_hasPendingAttackCheck`, and a generation counter `m_attackCheckGeneration` protected by `m_attackCheckMutex` to drop stale callbacks.
- Updated `Player::doAttacking` to capture and validate an attack-check `generation` when scheduling follow-up tasks and to call `requestAttackCheck` for classic-speed scheduling; preserved existing task setup for non-classic speeds with the new generation guard.
- Updated `Player::setAttackedCreature` to bump the generation, cancel any pending scheduled event, and request a new attack check with a computed delay based on `lastAttack` and `getAttackSpeed`.
- Added members and includes in `player.hpp` (`m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, `m_hasPendingAttackCheck`, and `m_attackCheckMutex`) and included `<mutex>`.

### Testing
- Ran the automated unit test suite related to combat and scheduling, and all tests passed.
- Performed automated integration/smoke tests by starting the server and exercising attack target changes, and the scheduling-related checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)