### PR TITLE
Debounce player attack-check events and prevent stale callbacks

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,17 +3754,28 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			uint32_t generation = 0;
+			{
+				std::scoped_lock lock(m_attackCheckMutex);
+				generation = m_attackCheckGeneration;
+			}
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						{
+							std::scoped_lock lock(player->m_attackCheckMutex);
+							if (generation != player->m_attackCheckGeneration) {
+								return;
+							}
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5785,6 +5796,18 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	uint64_t pendingAttackCheckEventId = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
+		m_pendingAttackCheckEventId = 0;
+		m_hasPendingAttackCheck = false;
+	}
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5823,87 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	uint32_t generation = 0;
+	uint64_t pendingAttackCheckEventIdToCancel = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (!getAttackedCreature()) {
+			return;
+		}
+
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			// Allow immediate retries to preempt delayed checks.
+			if (delay != 0) {
+				return;
+			}
+
+			pendingAttackCheckEventIdToCancel = m_pendingAttackCheckEventId;
+			m_pendingAttackCheckEventId = 0;
+			m_hasPendingAttackCheck = false;
+		}
+		generation = m_attackCheckGeneration;
+		m_hasPendingAttackCheck = true;
+	}
+	if (pendingAttackCheckEventIdToCancel != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventIdToCancel);
+	}
+
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	const auto eventId = g_dispatcher().scheduleEvent(
+		delay,
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+					return;
+				}
+
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	uint64_t eventIdToCancel = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration) {
+			m_pendingAttackCheckEventId = eventId;
+		} else if (eventId != 0) {
+			eventIdToCancel = eventId;
+		}
+
+		if (eventId == 0) {
+			m_hasPendingAttackCheck = false;
+		}
+	}
+
+	if (eventIdToCancel != 0) {
+		g_dispatcher().stopEvent(eventIdToCancel);
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5885,7 +5885,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	uint64_t eventIdToCancel = 0;
 	{

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -720,6 +722,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1811,10 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
+	std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation

- Prevent duplicate or stale attack-check dispatcher events when a player's attack target changes rapidly by debouncing scheduled callbacks. 
- Ensure only the most recent pending attack-check for a player runs and avoid running callbacks from older contexts (stale generations).

### Description

- Added `Player::requestAttackCheck(uint32_t delay)` implementing debounce semantics, scheduling an attack-check with `g_dispatcher().scheduleEvent`, cancelling previous pending events with `g_dispatcher().stopEvent`, and using a generation token to drop stale callbacks.
- Modified `Creature::checkCreatureAttack` to delegate player attack checks to `player->requestAttackCheck()` so player-specific debouncing is applied.
- Updated `Player::doAttacking` to capture an `m_attackCheckGeneration` snapshot and schedule a callback that verifies the generation under `m_attackCheckMutex` before calling `checkCreatureAttack(true)`, and to use `requestAttackCheck` for the classic-speed path.
- Updated `Player::setAttackedCreature` to increment `m_attackCheckGeneration`, cancel any pending scheduled event, compute a proper delay based on `lastAttack`/`getAttackSpeed()`, and call `requestAttackCheck(delay)` when a new target is set.
- Added player state and synchronization fields `m_pendingAttackCheckEventId`, `m_attackCheckGeneration`, `m_hasPendingAttackCheck`, and `m_attackCheckMutex`, and included `<mutex>` in `player.hpp` to protect these fields.

### Testing

- Built the server and ran the automated unit test suite, which completed successfully. 
- Ran automated integration/smoke tests exercising attack scheduling and target switching, which passed and showed no duplicate or stale attack-check invocations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)