### PR TITLE
Debounce and centralize Player attack-check scheduling

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,17 +3754,28 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			uint32_t generation = 0;
+			{
+				std::scoped_lock lock(m_attackCheckMutex);
+				generation = m_attackCheckGeneration;
+			}
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						{
+							std::scoped_lock lock(player->m_attackCheckMutex);
+							if (generation != player->m_attackCheckGeneration) {
+								return;
+							}
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5785,6 +5796,20 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	const bool hasTargetChanged = (creature != getAttackedCreature());
+	uint64_t pendingAttackCheckEventId = 0;
+	if (hasTargetChanged) {
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
+		m_pendingAttackCheckEventId = 0;
+		m_pendingAttackCheckDueTime = 0;
+		m_hasPendingAttackCheck = false;
+	}
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5825,96 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	uint32_t generation = 0;
+	uint64_t requestToken = 0;
+	uint64_t pendingAttackCheckEventIdToCancel = 0;
+	uint64_t now = OTSYS_TIME();
+	uint64_t newDueTime = now + delay;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (!getAttackedCreature()) {
+			return;
+		}
+
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			// Allow immediate retries or shorter delayed checks to preempt stale/longer pending checks.
+			const bool shouldPreemptPending = delay == 0 || (m_pendingAttackCheckDueTime != 0 && newDueTime < m_pendingAttackCheckDueTime);
+			if (!shouldPreemptPending) {
+				return;
+			}
+
+			pendingAttackCheckEventIdToCancel = m_pendingAttackCheckEventId;
+			m_pendingAttackCheckEventId = 0;
+			m_pendingAttackCheckDueTime = 0;
+			m_hasPendingAttackCheck = false;
+		}
+		generation = m_attackCheckGeneration;
+		requestToken = ++m_attackCheckRequestToken;
+		m_hasPendingAttackCheck = true;
+	}
+	if (pendingAttackCheckEventIdToCancel != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventIdToCancel);
+	}
+
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	const auto eventId = g_dispatcher().scheduleEvent(
+		delay,
+			[weakPlayer, generation, requestToken] {
+				const auto &player = weakPlayer.lock();
+				if (!player) {
+					return;
+			}
+
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+					if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration || requestToken != player->m_attackCheckRequestToken) {
+						return;
+					}
+
+					player->m_pendingAttackCheckEventId = 0;
+					player->m_pendingAttackCheckDueTime = 0;
+					player->m_hasPendingAttackCheck = false;
+				}
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	uint64_t eventIdToCancel = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+			if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration && requestToken == m_attackCheckRequestToken) {
+				m_pendingAttackCheckEventId = eventId;
+				m_pendingAttackCheckDueTime = eventId != 0 ? newDueTime : 0;
+			} else if (eventId != 0) {
+				eventIdToCancel = eventId;
+			}
+
+			if (eventId == 0) {
+				m_pendingAttackCheckDueTime = 0;
+				m_hasPendingAttackCheck = false;
+			}
+		}
+
+	if (eventIdToCancel != 0) {
+		g_dispatcher().stopEvent(eventIdToCancel);
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5875,42 +5875,43 @@ void Player::requestAttackCheck(uint32_t delay) {
 	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
 	const auto eventId = g_dispatcher().scheduleEvent(
 		delay,
-			[weakPlayer, generation, requestToken] {
-				const auto &player = weakPlayer.lock();
-				if (!player) {
-					return;
+		[weakPlayer, generation, requestToken] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
 			}
 
 			{
 				std::scoped_lock lock(player->m_attackCheckMutex);
 				// Drop stale callbacks from older generations or already-cleared state.
-					if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration || requestToken != player->m_attackCheckRequestToken) {
-						return;
-					}
-
-					player->m_pendingAttackCheckEventId = 0;
-					player->m_pendingAttackCheckDueTime = 0;
-					player->m_hasPendingAttackCheck = false;
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration || requestToken != player->m_attackCheckRequestToken) {
+					return;
 				}
+
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_pendingAttackCheckDueTime = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	uint64_t eventIdToCancel = 0;
 	{
 		std::scoped_lock lock(m_attackCheckMutex);
-			if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration && requestToken == m_attackCheckRequestToken) {
-				m_pendingAttackCheckEventId = eventId;
-				m_pendingAttackCheckDueTime = eventId != 0 ? newDueTime : 0;
-			} else if (eventId != 0) {
-				eventIdToCancel = eventId;
-			}
-
-			if (eventId == 0) {
-				m_pendingAttackCheckDueTime = 0;
-				m_hasPendingAttackCheck = false;
-			}
+		if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration && requestToken == m_attackCheckRequestToken) {
+			m_pendingAttackCheckEventId = eventId;
+			m_pendingAttackCheckDueTime = eventId != 0 ? newDueTime : 0;
+		} else if (eventId != 0) {
+			eventIdToCancel = eventId;
 		}
+
+		if (eventId == 0) {
+			m_pendingAttackCheckDueTime = 0;
+			m_hasPendingAttackCheck = false;
+		}
+	}
 
 	if (eventIdToCancel != 0) {
 		g_dispatcher().stopEvent(eventIdToCancel);

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -720,6 +722,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1811,12 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint64_t m_pendingAttackCheckDueTime = 0;
+	uint64_t m_attackCheckRequestToken = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
+	std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation

- Reduce duplicate or stale attack-check dispatcher events when players change targets rapidly by debouncing and centralizing scheduling per-player.
- Ensure attack checks are cancelled/preempted correctly when the attacked target changes to avoid unnecessary work and race conditions.

### Description

- Added `Player::requestAttackCheck(uint32_t delay = 0)` to debounce and schedule a single pending attack-check per player, with generation and request tokens to drop stale callbacks and support preemption. 
- Changed `Creature::checkCreatureAttack` to delegate player attack-checks to `Player::requestAttackCheck`, while keeping non-player creatures using the dispatcher as before. 
- Updated `Player::doAttacking` to use a generation-checked scheduled task for non-classic speed and to call `requestAttackCheck` for the classic-speed branch. 
- On attack target changes (`Player::setAttackedCreature`) increment the generation, cancel any pending dispatcher event, and use `requestAttackCheck` with a computed delay based on `lastAttack` and `getAttackSpeed`.
- Added per-player state and synchronization fields: `m_pendingAttackCheckEventId`, `m_pendingAttackCheckDueTime`, `m_attackCheckRequestToken`, `m_attackCheckGeneration`, `m_hasPendingAttackCheck`, and `m_attackCheckMutex`, and included `<mutex>` in the header.

### Testing

- Built the project locally; the build succeeded. 
- Ran the existing automated unit/integration tests; all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)