### PR TITLE
Debounce Player attack checks and centralize scheduling in Player::requestAttackCheck

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,17 +3754,28 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
-		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
-				} }, __FUNCTION__
-		);
-
 		if (!classicSpeed) {
+			uint32_t generation = 0;
+			{
+				std::scoped_lock lock(m_attackCheckMutex);
+				generation = m_attackCheckGeneration;
+			}
+			const auto &task = createPlayerTask(
+				std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+					if (const auto &player = self.lock()) {
+						{
+							std::scoped_lock lock(player->m_attackCheckMutex);
+							if (generation != player->m_attackCheckGeneration) {
+								return;
+							}
+						}
+
+						player->checkCreatureAttack(true);
+					} }, __FUNCTION__
+			);
 			setNextActionTask(task, false);
 		} else {
-			g_dispatcher().scheduleEvent(task);
+			requestAttackCheck(std::max<uint32_t>(SCHEDULER_MINTICKS, delay));
 		}
 
 		if (result) {
@@ -5785,6 +5796,20 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	const bool hasTargetChanged = (creature != getAttackedCreature());
+	uint64_t pendingAttackCheckEventId = 0;
+	if (hasTargetChanged) {
+		std::scoped_lock lock(m_attackCheckMutex);
+		++m_attackCheckGeneration;
+		pendingAttackCheckEventId = m_pendingAttackCheckEventId;
+		m_pendingAttackCheckEventId = 0;
+		m_pendingAttackCheckDueTime = 0;
+		m_hasPendingAttackCheck = false;
+	}
+	if (pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventId);
+	}
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5825,98 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
+}
+
+void Player::requestAttackCheck(uint32_t delay) {
+	uint32_t generation = 0;
+	uint64_t requestToken = 0;
+	uint64_t pendingAttackCheckEventIdToCancel = 0;
+	uint64_t now = OTSYS_TIME();
+	uint64_t newDueTime = now + delay;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (!getAttackedCreature()) {
+			return;
+		}
+
+		// Debounce: one pending attack-check event per player at a time.
+		if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+			// Allow immediate retries or shorter delayed checks to preempt stale/longer pending checks.
+			const bool shouldPreemptPending = delay == 0 || (m_pendingAttackCheckDueTime != 0 && newDueTime < m_pendingAttackCheckDueTime);
+			if (!shouldPreemptPending) {
+				return;
+			}
+
+			pendingAttackCheckEventIdToCancel = m_pendingAttackCheckEventId;
+			m_pendingAttackCheckEventId = 0;
+			m_pendingAttackCheckDueTime = 0;
+			m_hasPendingAttackCheck = false;
+		}
+		generation = m_attackCheckGeneration;
+		requestToken = ++m_attackCheckRequestToken;
+		m_pendingAttackCheckDueTime = newDueTime;
+		m_hasPendingAttackCheck = true;
+	}
+	if (pendingAttackCheckEventIdToCancel != 0) {
+		g_dispatcher().stopEvent(pendingAttackCheckEventIdToCancel);
+	}
+
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	const auto eventId = g_dispatcher().scheduleEvent(
+		delay,
+		[weakPlayer, generation, requestToken] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			{
+				std::scoped_lock lock(player->m_attackCheckMutex);
+				// Drop stale callbacks from older generations or already-cleared state.
+				if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration || requestToken != player->m_attackCheckRequestToken) {
+					return;
+				}
+
+				player->m_pendingAttackCheckEventId = 0;
+				player->m_pendingAttackCheckDueTime = 0;
+				player->m_hasPendingAttackCheck = false;
+			}
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
+
+	uint64_t eventIdToCancel = 0;
+	{
+		std::scoped_lock lock(m_attackCheckMutex);
+		if (m_hasPendingAttackCheck && generation == m_attackCheckGeneration && requestToken == m_attackCheckRequestToken) {
+			if (eventId != 0) {
+				m_pendingAttackCheckEventId = eventId;
+				m_pendingAttackCheckDueTime = newDueTime;
+			} else {
+				m_pendingAttackCheckEventId = 0;
+				m_pendingAttackCheckDueTime = 0;
+				m_hasPendingAttackCheck = false;
+			}
+		} else if (eventId != 0) {
+			eventIdToCancel = eventId;
+		}
+	}
+
+	if (eventIdToCancel != 0) {
+		g_dispatcher().stopEvent(eventIdToCancel);
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5895,7 +5895,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			}
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	uint64_t eventIdToCancel = 0;
 	{

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "creatures/creature.hpp"
 #include "enums/forge_conversion.hpp"
 #include "game/bank/bank.hpp"
@@ -720,6 +722,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1811,12 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint64_t m_pendingAttackCheckDueTime = 0;
+	uint64_t m_attackCheckRequestToken = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
+	std::mutex m_attackCheckMutex;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate or stale attack-check dispatcher events when a player's target changes rapidly by debouncing and centralizing scheduling for player attack checks.
- Allow shorter or immediate checks to preempt longer pending checks and ensure only relevant callbacks execute.

### Description
- Route `Creature::checkCreatureAttack` to `Player::requestAttackCheck` for player-controlled creatures to enable per-player debouncing behavior.
- Add `Player::requestAttackCheck(uint32_t delay)` which implements debounce semantics using a generation counter, request token, pending-event tracking, and `m_attackCheckMutex`, and which cancels or preempts pending scheduled events via `g_dispatcher().stopEvent` as needed.
- Update `Player::doAttacking` to capture a generation and schedule a task that verifies the generation under `m_attackCheckMutex` before calling `checkCreatureAttack(true)`, and use `requestAttackCheck` for the classic-speed path.
- Update `Player::setAttackedCreature` to increment the attack-check generation, cancel pending events when the target changes, compute appropriate delay from `lastAttack`/`getAttackSpeed()`, and call `requestAttackCheck(delay)`; add related members and include `<mutex>` in `player.hpp`.

### Testing
- Built the project with the normal build system (`make`/project build) and compilation succeeded without errors.
- Ran the automated unit test suite (`ctest`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7ed7e7308321bea53325fd859ecc)